### PR TITLE
25년 6월 4주차 문제 풀이 제출

### DIFF
--- a/Baekjoon/silver/괄호_9012/hana.java
+++ b/Baekjoon/silver/괄호_9012/hana.java
@@ -1,0 +1,42 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Main {
+
+	static StringBuilder sb = new StringBuilder();
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		int testCases = Integer.parseInt(br.readLine());
+
+		for (int i = 0; i < testCases; i++) {
+			char[] chars = br.readLine().toCharArray();
+
+			int balance = 0;
+			boolean isValid = true;
+
+			for (char c : chars) {
+				if (c == '(') {
+					balance++;
+				} else if (c == ')') {
+					balance--;
+				}
+
+				if (balance < 0) {
+					isValid = false;
+					break;
+				}
+			}
+
+			if (isValid && balance == 0) {
+				sb.append("YES\n");
+			} else {
+				sb.append("NO\n");
+			}
+		}
+
+		System.out.print(sb);
+	}
+}

--- a/Baekjoon/silver/요세푸스_1158/hana.java
+++ b/Baekjoon/silver/요세푸스_1158/hana.java
@@ -1,0 +1,42 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Main {
+
+	static StringBuilder sb = new StringBuilder();
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+
+		int n = Integer.parseInt(st.nextToken()); 
+		int k = Integer.parseInt(st.nextToken()); 
+
+		Queue<Integer> circle = new ArrayDeque<>();
+		for (int i = 1; i <= n; i++) {
+			circle.offer(i);
+		}
+
+		sb.append('<');
+
+		int cursor = 1;
+
+		while (!circle.isEmpty()) {
+			if (cursor == k) {
+				sb.append(circle.poll());
+				if (!circle.isEmpty()) sb.append(", ");
+				cursor = 1;
+			} else {
+				circle.offer(circle.poll());
+				cursor++;
+			}
+		}
+
+		sb.append('>');
+		System.out.print(sb);
+	}
+}


### PR DESCRIPTION
### ✅ 정해진 문제를 다 풀었나요?
- 네

---

### ⏱️ 체감 난이도  
- 괄호: 3/10  
- 요세푸스: 5/10  

---

### 🧠 사용한 자료구조  
- 괄호: `int 변수`, `char 배열`  
- 요세푸스: `Queue (ArrayDeque)`, `StringBuilder`

---

### ⌛ 시간복잡도  

- **괄호 문제**  
  한 문자열을 한 글자씩 순회하므로  
  **O(n)** (n은 문자열 길이)  
  테스트케이스 T개 → 총 O(T × n)

- **요세푸스 문제**  
  사람 수 n명에 대해, k번째 사람을 제거할 때마다  
  최악의 경우 n명 모두 순회 → O(nk)  
  하지만 로직상 실제로는 n번만 제거하므로  
  **O(n)** (큐에서 제거/삽입 연산)

---

### 📝 어려웠던 점  

- **괄호 문제**  
  - 여는 괄호와 닫는 괄호의 균형만 보면 되는 문제였지만, 중간에 `balance < 0` 체크를 넣지 않으면 틀리는 테스트 케이스가 존재함
  - 괄호 짝만 판단하는 간단한 문제지만 `boolean` 플래그 활용으로 가독성을 높임

- **요세푸스 문제**  
  - 처음엔 단순 `List`로 인덱스를 관리하려 했으나 시간복잡도 고려해 `Queue`로 전환  
  - 마지막 원소 뒤에도 `,`가 찍히지 않도록 문자열 출력 형식에 유의

---

### 📚 참고사항 혹은 추가로 공부할 점  

- 괄호 문제는 스택을 사용하지 않고도 balance 변수 하나로 해결 가능한 대표적인 문제  
- 요세푸스 문제는 **자료구조 선택**이 핵심  
  - Queue를 이용하면 시간 효율이 좋음  
  - Java의 `ArrayDeque`가 `LinkedList`보다 빠르므로 적절히 선택  
- 나중에 이 문제를 **LinkedList로 순환 구현**하거나, **수학적으로 푸는 방법**도 도전해보면 좋을 것 같음
